### PR TITLE
feat(cli): improve usability and add output suppression

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-echo "Building gotranscribe..."
+echo "Building go-transcribe..."
 
 # Get the absolute path to the project root directory.
 # This makes the script runnable from any directory.


### PR DESCRIPTION
This commit introduces several enhancements to the CLI:

- **Default Command:** The CLI now defaults to the 'transcribe' command if no explicit command is provided. This simplifies the most common use case.
- **Output Suppression:** C++ output from the underlying whisper.cpp library is now captured and suppressed, providing a cleaner user experience. This output is printed only if an error occurs, aiding in debugging.
- **Configuration:** The configuration file is now stored at '~/.config/go-transcribe.json', and a default configuration is automatically created on first run of the 'setup' command.
- **ffmpeg:** Switched to quieter ffmpeg logging.