### PR TITLE
Fix: Resolve CI Build Failure for ARM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake pkg-config
       - name: Build whisper.cpp bindings
         run: make -C whisper.cpp/bindings/go WHISPER_NO_I8MM=1
       - name: Semantic Release

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ GEMINI.md
 
 # Compiled binary
 go-transcribe
+
+# secrets
+.secrets

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,8 +12,7 @@ builds:
     binary: go-transcribe
     env:
       - CGO_ENABLED=1
-      - WHISPER_NO_I8MM=1
-      - CGO_CFLAGS=-I{{ .Env.GITHUB_WORKSPACE }}/whisper.cpp/include -I{{ .Env.GITHUB_WORKSPACE }}/whisper.cpp/ggml/include
+      - CGO_CFLAGS=-I{{ .Env.GITHUB_WORKSPACE }}/whisper.cpp/include -I{{ .Env.GITHUB_WORKSPACE }}/whisper.cpp/ggml/include -DWHISPER_NO_I8MM
       - CGO_LDFLAGS=-L{{ .Env.GITHUB_WORKSPACE }}/whisper.cpp/build_go/src -L{{ .Env.GITHUB_WORKSPACE }}/whisper.cpp/build_go/ggml/src -L{{ .Env.GITHUB_WORKSPACE }}/whisper.cpp/build_go/ggml/src/ggml-metal -L{{ .Env.GITHUB_WORKSPACE }}/whisper.cpp/build_go/ggml/src/ggml-blas
     goos:
       - darwin


### PR DESCRIPTION
This PR fixes the ARM build failure in the CI pipeline by updating the whisper.cpp submodule and adding the necessary build flags and dependencies to the workflow.